### PR TITLE
Add restore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Do you use Slack? Do you share links with your co-workers?
 SlackBot-Links store all theses urls, enrich them with metadata, and expose them through a REST API.
 You can now find shared urls by searching in their title, content, author name...
 
+
 ## Get Started
 
 ### 1. Build Slackbot Links
@@ -50,6 +51,7 @@ You can now share link on `#links` and fetch them using REST API :
 curl localhost:9300/v1/links/
 ```
 
+
 ## API
 
 REST API Documentation can be found [here](https://jguyomard.github.io/slackbot-links).
@@ -62,6 +64,20 @@ make docapi
 ```
 
 
+## Commands
+
+### `restore`
+
+This command recreates the Elasticsearch index from a given `links.log` log file.
+This is very useful for fast testing with a given scenario, or for initializing a staging environment, for instance.
+
+```
+slackbot-links -config-file=/etc/slackbot-links/config.yaml -links-file=./links-tests.log restore
+```
+
+If a link already exists (same ID), it is updated.
+
+
 ## Testing
 
 To run the test suite:
@@ -69,6 +85,7 @@ To run the test suite:
 ```
 make test
 ```
+
 
 ## Issues
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/jguyomard/slackbot-links/src/api"
 	"github.com/jguyomard/slackbot-links/src/config"
@@ -13,6 +14,7 @@ func main() {
 
 	// Read command options
 	configFilePtr := flag.String("config-file", "/etc/slackbot-links/config.yaml", "conf file path")
+	linksFilePtr := flag.String("links-file", "", "links file path")
 	flag.Parse()
 
 	// Set config filepath
@@ -20,6 +22,15 @@ func main() {
 
 	// Connect to ES
 	links.Init()
+
+	// Commands
+	if flag.Arg(0) == "restore" {
+		if *linksFilePtr == "" {
+			panic("--links-file is mandadory.")
+		}
+		links.Restore(*linksFilePtr)
+		os.Exit(0)
+	}
 
 	// Listen for new Slack Messages
 	go slackbot.Listen()

--- a/src/links/restore.go
+++ b/src/links/restore.go
@@ -1,0 +1,101 @@
+package links
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+type logData struct {
+	Action string
+	Level  string
+	Msg    string
+	Time   *time.Time
+	Link   Link
+}
+
+var (
+	linksIdsAnalysed = []string{}
+)
+
+// Restore links from json file
+func Restore(filepath string) bool {
+
+	file, err := os.Open(filepath)
+	if err != nil {
+		fmt.Println("Error opening links-file:", err)
+		os.Exit(1)
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		restoreLink(scanner.Bytes())
+	}
+
+	if err = scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	return true
+}
+
+func restoreLink(lineStr []byte) bool {
+	var line logData
+
+	// json decode
+	if err := json.Unmarshal(lineStr, &line); err != nil {
+		fmt.Printf("jsonDecode ERROR (Unmarshal): %v\n", err)
+		return false
+	}
+
+	switch line.Action {
+
+	// Save Link (insert or update)
+	case "save":
+		if linkAlreadyAnalysed(line.Link) {
+			fmt.Printf(" - Link %s (url=%s) already analysed. Continue.\n", line.Link.ID, line.Link.URL)
+			return false
+		}
+		if line.Link.Save() {
+			markLinkAsAnalysed(line.Link)
+			fmt.Printf(" - Link %s (%s) restored.\n", line.Link.ID, line.Link.URL)
+			return true
+		}
+		fmt.Printf(" - Error saving Link %s (%s). Continue.\n", line.Link.ID, line.Link.URL)
+		return false
+
+	// Delete Link
+	case "delete":
+		if line.Link.Delete() {
+			fmt.Printf(" - Link %s (%s) deletion restored.\n", line.Link.ID, line.Link.URL)
+			return true
+		}
+		fmt.Printf(" - Error deleting Link %s (%s). Continue.\n", line.Link.ID, line.Link.URL)
+		return false
+
+	}
+
+	return false
+}
+
+func markLinkAsAnalysed(link Link) {
+	linksIdsAnalysed = append(linksIdsAnalysed, link.ID)
+}
+
+func linkAlreadyAnalysed(link Link) bool {
+	return inArr(link.ID, linksIdsAnalysed)
+}
+
+func inArr(str string, arr []string) bool {
+	for _, val := range arr {
+		if str == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This command recreates the Elasticsearch index from a given `links.log` log file.
This is very useful for fast testing with a given scenario, or for initializing a staging environment, for instance.

```
slackbot-links -config-file=/etc/slackbot-links/config.yaml -links-file=./links-tests.log restore
```

If a link already exists (same ID), it is updated.

